### PR TITLE
Cleanup: Rename remaining fsm references to filegate (#7)

### DIFF
--- a/filegate/__init__.py
+++ b/filegate/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '1.1.3'
-__author__ = 'FSM'
+__author__ = 'FileGate'

--- a/filegate/commands/shell.py
+++ b/filegate/commands/shell.py
@@ -34,7 +34,7 @@ from filegate.protocols.base import BaseServer, FSEntry, EntryType
 console = Console()
 
 SHELL_HELP = """
-[bold cyan]FSM Interactive Shell Commands[/]
+[bold cyan]FileGate Interactive Shell Commands[/]
 
   [yellow]ls[/] [path]         List remote directory contents
   [yellow]cd[/] <path>         Change remote directory

--- a/filegate/completer.py
+++ b/filegate/completer.py
@@ -1,5 +1,5 @@
 """
-completer.py — TAB completion engine for FSM.
+completer.py — TAB completion engine for FileGate.
 
 Provides:
   1. RemoteCompleter   — readline completer for remote paths (interactive mode)

--- a/filegate/protocols/base.py
+++ b/filegate/protocols/base.py
@@ -36,7 +36,7 @@ ProgressCallback = Callable[[int, int], None]   # (transferred_bytes, total_byte
 
 class BaseServer(ABC):
     """
-    Abstract base for all FSM server backends.
+    Abstract base for all FileGate server backends.
 
     Subclasses must implement the abstract methods below.
     All paths are POSIX-style regardless of the underlying protocol.


### PR DESCRIPTION
This pull request replaces all remaining occurrences of fsm/FSM with filegate/FileGate across the codebase. Closes #7.