### PR TITLE
Fix: Standardize transfer output and remove completed progress tasks (#12)

### DIFF
--- a/filegate/commands/copy.py
+++ b/filegate/commands/copy.py
@@ -24,6 +24,16 @@ def parse_remote_path(path_str: str) -> Tuple[str, str]:
     return server, path or '/'
 
 
+def _format_size(size_bytes: int) -> str:
+    if size_bytes >= 1_073_741_824:
+        return f"{size_bytes / 1_073_741_824:.1f} GB"
+    if size_bytes >= 1_048_576:
+        return f"{size_bytes / 1_048_576:.1f} MB"
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes} B"
+
+
 def cmd_copy(args):
     console = Console()
     src_name, src_path = parse_remote_path(args.src)
@@ -124,6 +134,7 @@ def cmd_copy(args):
                                     f_dst.write(chunk)
                                     progress.update(task, advance=len(chunk))
                                 progress.remove_task(task)
+                                console.print(f"[green]✓[/] Copied [bold]{filename}[/] ({_format_size(total_size)})")
 
                     # If destination is a directory, append source name to it
                     final_dst = dst_path

--- a/filegate/commands/pull.py
+++ b/filegate/commands/pull.py
@@ -31,6 +31,16 @@ from filegate.protocols import get_server_instance
 console = Console()
 
 
+def _format_size(size_bytes: int) -> str:
+    if size_bytes >= 1_073_741_824:
+        return f"{size_bytes / 1_073_741_824:.1f} GB"
+    if size_bytes >= 1_048_576:
+        return f"{size_bytes / 1_048_576:.1f} MB"
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes} B"
+
+
 def _make_progress() -> Progress:
     return Progress(
         SpinnerColumn(),
@@ -151,6 +161,8 @@ def cmd_pull(args) -> None:
                 # Ensure parent local dir exists
                 Path(l_path).parent.mkdir(parents=True, exist_ok=True)
                 server.pull(r_path, l_path, progress=cb)
+                progress.remove_task(task_id)
+                console.print(f"[green]✓[/] Pulled [bold]{fname}[/] ({_format_size(total_size)})")
 
         try:
             _do_pull(remote_path, local_path)

--- a/filegate/commands/push.py
+++ b/filegate/commands/push.py
@@ -29,6 +29,16 @@ from filegate.protocols import get_server_instance
 console = Console()
 
 
+def _format_size(size_bytes: int) -> str:
+    if size_bytes >= 1_073_741_824:
+        return f"{size_bytes / 1_073_741_824:.1f} GB"
+    if size_bytes >= 1_048_576:
+        return f"{size_bytes / 1_048_576:.1f} MB"
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes} B"
+
+
 def _make_progress() -> Progress:
     return Progress(
         SpinnerColumn(),
@@ -144,6 +154,8 @@ def cmd_push(args) -> None:
                     progress.update(task_id, completed=transferred, total=total)
                 
                 server.push(l_path, r_path, progress=cb)
+                progress.remove_task(task_id)
+                console.print(f"[green]✓[/] Pushed [bold]{fname}[/] ({_format_size(total_size)})")
 
         try:
             _do_push(local_path, remote_path)


### PR DESCRIPTION
This PR standardizes progress outputs across pull, push, and copy commands. Completed progress tasks are removed from the active screen and printed as static status lines. Closes #12.