### PR TITLE
Fix tab completion for paths containing parentheses

### DIFF
--- a/completions/bash_completion
+++ b/completions/bash_completion
@@ -26,8 +26,8 @@ _filegate_filedir() {
 _filegate_complete() {
     local cur prev words cword
     if declare -f _init_completion > /dev/null 2>&1; then
-        # Initialize with colon as a non-breaking character
-        _init_completion -n : || return
+        # Initialize with colon and parentheses as non-breaking characters
+        _init_completion -n ":()" || return
     else
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/filegate/completer.py
+++ b/filegate/completer.py
@@ -184,8 +184,8 @@ _filegate_filedir() {
 _filegate_complete() {
     local cur prev words cword
     if declare -f _init_completion > /dev/null 2>&1; then
-        # Initialize with colon as a non-breaking character
-        _init_completion -n : || return
+        # Initialize with colon and parentheses as non-breaking characters
+        _init_completion -n ":()" || return
     else
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/filegate/main.py
+++ b/filegate/main.py
@@ -182,6 +182,22 @@ def main() -> None:
         sys.exit(1)
 
 
+def _unescape_path(s: str) -> str:
+    res = []
+    escape = False
+    for char in s:
+        if escape:
+            res.append(char)
+            escape = False
+        elif char == '\\':
+            escape = True
+        else:
+            res.append(char)
+    if escape:
+        res.append('\\')
+    return ''.join(res)
+
+
 def _do_remote_complete(server_name: str, partial: str) -> None:
     """
     Print remote path completions for *partial* on *server_name*.
@@ -191,6 +207,7 @@ def _do_remote_complete(server_name: str, partial: str) -> None:
     from filegate.protocols import get_server_instance
     from filegate.completer import RemoteCompleter
 
+    partial = _unescape_path(partial)
     conf = cfg.get_server(server_name)
     if not conf:
         sys.exit(0)


### PR DESCRIPTION
Fixes issue #18. Treats parentheses as non-breaking characters in bash completion.