### PR TITLE
Remove fgate shorthand alias from project

### DIFF
--- a/.agents/skills/filegate/SKILL.md
+++ b/.agents/skills/filegate/SKILL.md
@@ -5,11 +5,11 @@ description: Reference and instructions for running and using the filegate CLI a
 
 # FileGate Assistant
 
-This skill provides reference instructions for using the FileGate (`filegate` or `fgate`) application.
+This skill provides reference instructions for using the FileGate (`filegate`) application.
 
 ## CLI Usage Reference
 
-Antigravity can run the `filegate` or `fgate` command directly to invoke various subcommands. Below is the command reference.
+Antigravity can run the `filegate` command directly to invoke various subcommands. Below is the command reference.
 
 ### 1. Registering Servers
 To connect to remote file servers, you must first register them:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ pipx install .
 
 ## Quick Start
 
-You can use either `filegate` or the shorthand `fgate`. Both work identically!
-
 ```bash
 # Register servers
 filegate add mynas  --host 192.168.1.10 --user admin  --protocol sftp --key ~/.ssh/id_rsa

--- a/completions/_filegate
+++ b/completions/_filegate
@@ -1,4 +1,4 @@
-#compdef filegate fgate
+#compdef filegate
 # FileGate zsh completion
 
 _filegate() {

--- a/completions/bash_completion
+++ b/completions/bash_completion
@@ -174,4 +174,4 @@ _filegate_complete() {
 }
 
 # Apply to all possible command names
-complete -F _filegate_complete filegate fgate filegate.fgate
+complete -F _filegate_complete filegate

--- a/filegate/completer.py
+++ b/filegate/completer.py
@@ -331,12 +331,12 @@ _filegate_complete() {
     esac
 }
 
-complete -F _filegate_complete filegate fgate filegate.fgate
+complete -F _filegate_complete filegate
 """
 
 
 def generate_zsh_completion() -> str:
-    return r"""#compdef filegate fgate
+    return r"""#compdef filegate
 # FileGate zsh completion
 
 _filegate() {

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     entry_points={
         'console_scripts': [
             'filegate=filegate.main:main',
-            'fgate=filegate.main:main',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Removes all references to the fgate command alias from configuration, autocompletion scripts, documentation, and agent skills.